### PR TITLE
DockerClientException will use response instead of response.content

### DIFF
--- a/src/main/groovy/de/gesellix/docker/client/DockerResponseHandler.groovy
+++ b/src/main/groovy/de/gesellix/docker/client/DockerResponseHandler.groovy
@@ -10,7 +10,7 @@ class DockerResponseHandler {
   def ensureSuccessfulResponse(def response, Throwable context) {
     if (!response || !response.status.success || hasError(response)) {
       logError(response)
-      throw new DockerClientException(context, response?.content)
+      throw new DockerClientException(context, response)
     }
   }
 


### PR DESCRIPTION
DockerClientException will use response instead of response.content